### PR TITLE
Set Submit as default value for form tracking mode

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -100,6 +100,7 @@ ___TEMPLATE_PARAMETERS___
           }
         ],
         "simpleValueType": true,
+        "defaultValue": "submit",
         "notSetText": "Don\u0027t Track"
       },
       {


### PR DESCRIPTION
Fixes the bug introduced with https://github.com/SalesWings/gtm-sw-init/commit/aaa7f8609c96a3df91fcbd6d068b9d4f22f5f143.

Tested in GTM template editor UI, the default value is set to "Submit" as expected.