### PR TITLE
Fix default form tracking behavior for legacy tag instances

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -955,7 +955,7 @@ scenarios:
       }
       return undefined;
     })();
-    assertThat(trackFormsCall).isNotUndefined();
+    assertThat(trackFormsCall).isDefined();
     assertThat(trackFormsCall.params.mode).isEqualTo('submit');
     assertThat(trackFormsCall.params.delay).isUndefined();
     assertApi('gtmOnSuccess').wasCalled();

--- a/template.tpl
+++ b/template.tpl
@@ -375,7 +375,7 @@ if(data.trackhashchange || data.tracklocationchange){
     ); 
 }
 
-if(data.trackformsenabled){
+if(data.trackformsenabled !== false){
   sw('trackForms', {
     mode: data.trackformsmode || 'submit',
     delay: data.trackformsdelay});
@@ -926,6 +926,38 @@ scenarios:
       return undefined;
     })();
     assertThat(trackFormsCall).isUndefined();
+    assertApi('gtmOnSuccess').wasCalled();
+
+- name: sw_trackForms_undefined_upgrade_scenario
+  code: |-
+    const mockData = {
+      pid: '123e4567-e89b-12d3-a456-426655440000'
+    };
+
+    let capturedSwCalls = [];
+    mock('createArgumentsQueue', function(name, queue) {
+      return function(action, params) {
+        capturedSwCalls.push({
+          name: name,
+          action: action,
+          params: params
+        });
+      };
+    });
+
+    runCode(mockData);
+
+    const trackFormsCall = (function() {
+      for (let i = 0; i < capturedSwCalls.length; i++) {
+        if (capturedSwCalls[i].action === 'trackForms') {
+          return capturedSwCalls[i];
+        }
+      }
+      return undefined;
+    })();
+    assertThat(trackFormsCall).isNotUndefined();
+    assertThat(trackFormsCall.params.mode).isEqualTo('submit');
+    assertThat(trackFormsCall.params.delay).isUndefined();
     assertApi('gtmOnSuccess').wasCalled();
 
 - name: sw_enablePopups_with_url


### PR DESCRIPTION
The defaults for the new fields are shown in the UI, but are not applied to tag properties. This change ensures that all tag instances created with versions prior to 4f50debc777b273cf1834f16c8f5de6c376b2c9b will still have form tracking enabled by default.

Tested the scenarios as follows.

#### Legend
Version 1 - 632ab290aecdb134769b419e4b34f03ae2363b75 - Last one before the latest release
Version 2 - 4f50debc777b273cf1834f16c8f5de6c376b2c9b - Latest release (Form tracking enabled checkbox, Interactions section, etc.)
Version 3 - This PR

#### Scenario 1
Version 1 is installed →  auto-tracking works
Version 1 upgraded to Version 2 → auto-tracking no longer works, although Form tracking is shown as "Enabled"
Version 2 upgraded to Version 3 → auto-tracking works again, Form tracking is shown as "Enabled"

#### Scenario 2
Fresh installation of Version 3
Auto-tracking works, Form tracking is shown as "Enabled"

#### Scenario 3a
Fresh installation of Version 3
Form tracking enabled checkbox is explicitly unchecked before publishing
Auto-tracking does NOT work

#### Scenario 3b
Fresh installation of Version 3
Auto-tracking works, Form tracking is shown as "Enabled"
Tag is published
Form tracking enabled checkbox is explicitly unchecked
Tag is published
Auto-tracking does NOT work

#### Scenario 4
Version 1 is installed →  auto-tracking works
Version 1 is upgraded directly to Version 3 → auto-tracking works again, Form tracking is shown as "Enabled" 